### PR TITLE
Fix to halfproc.cpp

### DIFF
--- a/25/src/densitysimcomp.cpp
+++ b/25/src/densitysimcomp.cpp
@@ -88,7 +88,15 @@ void remove_tags(dmatrix& density, const imatrix map, const int region_drop)
     }
 }
 
-
+void initial_prev_zs(const dvector& sum0, dvector& prev_sum)
+{
+  int k1 = sum0.indexmin();
+  int k2 = sum0.indexmax();
+    for (int k = k1; k <= k2; k++)
+      {
+	prev_sum(k) = sum0(k);
+      }
+}
 
 void halfcomp(const dmatrix& density, dmatrix& prev_density, 
               const double curr_time, double& prev_time,

--- a/25/src/halfcomp.cpp
+++ b/25/src/halfcomp.cpp
@@ -2,6 +2,16 @@
 #include <fvar.hpp>
 //#include "trace.h"
 
+void initial_prev_zs(const dvector& sum0, dvector& prev_sum)
+{
+  int k1 = sum0.indexmin();
+  int k2 = sum0.indexmax();
+  for (int k = k1; k <= k2; k++)
+    {
+      prev_sum(k) = sum0(k);
+    }
+}
+
 void halfcomp(const dmatrix& density, dmatrix& prev_density, 
               const double curr_time, double& prev_time,
               const double half, 

--- a/25/src/halfproc.cpp
+++ b/25/src/halfproc.cpp
@@ -287,7 +287,7 @@ void par_t_reg<d3_array,dmatrix,dvector,double>::halflife(indexed_regional_fishe
   {
     double curr_time = 0.0;
     double prev_time = curr_time;
-    zonesum0.initialize();
+    //zonesum0.initialize();
 
     year_month start_date(1,start_month); // average effort starts in year 1
     year_month final_date = start_date + nmonth - 1;

--- a/25/src/halfproc.cpp
+++ b/25/src/halfproc.cpp
@@ -25,6 +25,7 @@ extern indexed_regional_fishery_record global_irfr;
   extern intersavetype *isp;
 #endif
 
+void initial_prev_zs(const dvector& sum0, dvector& prev_sum);
 void halfcomp(const dmatrix& density, const imatrix map, dvector& sum0, 
               dvector& prev_sum, dvector& cur_sum, 
               const double cur_time, double& prev_time,
@@ -297,6 +298,7 @@ void par_t_reg<d3_array,dmatrix,dvector,double>::halflife(indexed_regional_fishe
     prev_tags = tags;
     half_life = -1.0;
     zone_half_life = -1.0;
+    initial_prev_zs(zonesum0, prev_zs); // Assign starting values of prev_zs - required for estimation of halflives < 1 month
 
     for (year_month date = start_date; date <= final_date; date++)
     {


### PR DESCRIPTION
Hi John,

As mentioned previously, when developing rdensitysim, it looked like rhalflife was calculating halflives  based on tag numbers at time step 1 (but estimating halflife as if it were tag numbers at time step 0).

Intialisation of zonesum0 within the start month loop appears to be causing this (as this results in zonesum0 being set to curr_sum for year_month = start_date, when calling halfcomp).

There's probably many ways of addressing this, but I think the simplest would be commenting out the (re)intialisation of zonesum0 within the start month loop - the approach I've taken here.

I've double-checked by calculating halflives with no advective movement, no fishing mortality and uniform diffusion, and the halflife estimates are over-estimated by 1 month (compared to simply estimating halflife with natural mortality).

Thanks,
Tom

